### PR TITLE
Toggling alwaysOnTop forces focus on chess window.

### DIFF
--- a/src/main/java/com/caffeine/view/Core.java
+++ b/src/main/java/com/caffeine/view/Core.java
@@ -53,8 +53,13 @@ public class Core {
         addMenu(window);
         addMainPanels(window);
         window.pack();
-        window.setVisible(true);
         window.setResizable(false);
+        window.setVisible(true);
+
+        // 	Windows doesn't permit a VM to initially bring a window to focus,
+        // 	so this forces the chess window to be focused
+        window.setAlwaysOnTop(true);
+        window.setAlwaysOnTop(false);
     }
 
     /**


### PR DESCRIPTION
Window doesn't let VM force focus on a process apparently, but toggling the JFrame.setAlwaysOnTop() works around this and brings the chess game to the front. [fixes #26 ]